### PR TITLE
fix: grammatical error in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Simple Jekyll site for hosting all of the links from meetups past and future.
 ## Development
 
 You'll need [Ruby & Jekyll](https://jekyllrb.com/docs/installation/) to run the
-site locally. Once they're setup:
+site locally. Once they're set-up:
 
 * Clone the repository and go into the directory
 * Run `bundle install`


### PR DESCRIPTION
"Setup" is a noun referring to the arrangement or organization of something, while "set up" is a phrasal verb meaning to establish or prepare something. The instructions are describing actions, hence "set up" is appropriate.